### PR TITLE
Inject rest.Interface in k8s kv

### DIFF
--- a/kv/kubernetes/controller.go
+++ b/kv/kubernetes/controller.go
@@ -8,13 +8,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
-func (c *Client) startController() error {
+func (c *Client) startController(restClient rest.Interface) error {
 	// create the pod watcher
-	configMapWatcher := cache.NewFilteredListWatchFromClient(c.clientset.CoreV1().RESTClient(), "configMaps", c.namespace, func(options *metav1.ListOptions) {
+	configMapWatcher := cache.NewFilteredListWatchFromClient(restClient, "configMaps", c.namespace, func(options *metav1.ListOptions) {
 		options.FieldSelector = "metadata.name=" + c.name
 	})
 

--- a/kv/kubernetes/mock.go
+++ b/kv/kubernetes/mock.go
@@ -7,15 +7,15 @@ import (
 
 	"github.com/grafana/dskit/kv/codec"
 
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	fake_rest "k8s.io/client-go/rest/fake"
 )
 
 func NewInMemoryClient(codec codec.Codec, logger log.Logger) (*Client, io.Closer) {
-	fakeClientset := fake.NewSimpleClientset()
-
-	client, err := newClient(&Config{}, codec, logger, nil, func(c *Client) error {
-		c.clientset = fakeClientset
-		return nil
+	client, err := newClient(&Config{}, codec, logger, nil, func() (string, kubernetes.Interface, rest.Interface, error) {
+		return "", fake.NewSimpleClientset(), &fake_rest.RESTClient{}, nil
 	})
 	if err != nil {
 		panic("error generating in memory client: " + err.Error())


### PR DESCRIPTION
The rest client that's coming from the fake clientset [is nil](https://github.com/kubernetes/client-go/blob/master/kubernetes/typed/core/v1/fake/fake_core_client.go#L95-L100). We need to inject a fake rest client in tests.

